### PR TITLE
fix(useWPContent): prevent undefined access in findData function

### DIFF
--- a/src/runtime/composables/useWPContent.ts
+++ b/src/runtime/composables/useWPContent.ts
@@ -31,7 +31,7 @@ const findData = (data: unknown, nodes: string[]) => {
   if (nodes.length === 0) return data
   if (nodes.length > 0) {
     return nodes.reduce((acc, node) => {
-      return acc[node]
+      return acc[node] ?? acc
     }, data)
   }
 }


### PR DESCRIPTION
Previously, when accessing nested WordPress data, like for instance `author.node.name` on posts, the generated function would look something like:
```ts
export const useWPPosts = (params) => useWPContent('query', 'Posts', ['posts','nodes','node','name'], false, params)
```
Traversal would return `undefined` on `node` and `name` nodes and fail.

I considered fixing this by preventing `node` and `name` from appearing in the nodes array during generation, but that approach seemed risky and complex to implement reliably. Instead, this PR addresses the issue by making the traversal more resilient to missing nodes.
